### PR TITLE
feat: Adds ability to replace files inside zip file

### DIFF
--- a/updater.go
+++ b/updater.go
@@ -260,7 +260,7 @@ func (u *Updater) AppendHeaderAt(fh *FileHeader, offset int64) (io.Writer, error
 		}
 
 		// File does not exist inside the zip, so we append it
-		if existingFileIndex >= 0 {
+		if existingFileIndex < 0 {
 			offset = u.dirOffset
 		}
 	} else {
@@ -275,7 +275,7 @@ func (u *Updater) AppendHeaderAt(fh *FileHeader, offset int64) (io.Writer, error
 		}
 	}
 
-	if existingFileIndex > 0 {
+	if existingFileIndex >= 0 {
 		// If the file exists and is not the last one in the file, we will remove it
 		// and reinsert it at the end of the file.
 		// The existing files data will be relocated first to use the leftover space.

--- a/updater.go
+++ b/updater.go
@@ -280,7 +280,7 @@ func (u *Updater) AppendHeaderAt(fh *FileHeader, offset int64) (io.Writer, error
 		// and reinsert it at the end of the file.
 		// The existing files data will be relocated first to use the leftover space.
 
-		// This diagram shows the internal structure of a zip file, whose i-nth file
+		// This diagram shows the internal structure of a zip file, whose i-th file
 		// we want to overwrite. The annotations represent some of the variables that
 		// are used to implement this feature.
 		//

--- a/updater.go
+++ b/updater.go
@@ -248,7 +248,7 @@ func (u *Updater) AppendHeaderAt(fh *FileHeader, offset int64) (io.Writer, error
 	// Offset should match existing header offsets or equal to directory offset.
 	var offsetExists bool
 
-	existingFileIndex := 0
+	existingFileIndex := -1
 	if offset < 0 {
 		// Append the file to the zip or replace the existing one
 		for i, h := range u.dir {
@@ -260,7 +260,7 @@ func (u *Updater) AppendHeaderAt(fh *FileHeader, offset int64) (io.Writer, error
 		}
 
 		// File does not exist inside the zip, so we append it
-		if existingFileIndex == 0 {
+		if existingFileIndex >= 0 {
 			offset = u.dirOffset
 		}
 	} else {

--- a/updater.go
+++ b/updater.go
@@ -316,14 +316,11 @@ func (u *Updater) AppendHeaderAt(fh *FileHeader, offset int64) (io.Writer, error
 					return nil, err
 				}
 
-				// Rewind the ReadWriter offset a number of bytes equal to the size of the deleted data
-				_, err = u.rw.Seek(int64(u.dir[i].offset-deletedDataSize), io.SeekStart)
+				// Rewind the existing data a number of bytes equal to the size of the deleted data
+				_, err = u.rw.WriteAt(data, int64(u.dir[i].offset-deletedDataSize))
 				if err != nil {
 					return nil, err
 				}
-
-				// Write the data we read earlier onto its new destination
-				u.rw.Write(data)
 
 				// Update the file offsets in their headers, to match their new positions
 				u.dir[i].offset = u.dir[i].offset - uint64(deletedDataSize)

--- a/updater.go
+++ b/updater.go
@@ -328,6 +328,9 @@ func (u *Updater) AppendHeaderAt(fh *FileHeader, offset int64) (io.Writer, error
 				// Update the file offsets in their headers, to match their new positions
 				u.dir[i].offset = u.dir[i].offset - uint64(deletedDataSize)
 			}
+
+			// The dir offset also has to be reduced by the deleted data size
+			u.dirOffset = u.dirOffset - int64(deletedDataSize)
 		}
 
 		offset = u.dirOffset

--- a/updater.go
+++ b/updater.go
@@ -286,9 +286,7 @@ func (u *Updater) AppendHeaderAt(fh *FileHeader, offset int64) (io.Writer, error
 		//
 		//                       deletedDataSize = nextOffset - existingFileOffset
 		//                      ┌────────────────┐
-		//                      │                │ remainingDataSize
-		//                      │                ├────────────────────┐
-		//                      ▼                ▼                    ▼
+		//                      ▼                ▼
 		// ┌───┬────────────┬───┬───┬────────────┬───┬────────────┬───┬───────┐
 		// │   │            │   │   │            │   │            │   │░░░░░░░│
 		// │h_0│   File 0   │...│h_i│   File i   │h_ │  File i+1  │...│░░Dir░░│

--- a/updater.go
+++ b/updater.go
@@ -311,7 +311,7 @@ func (u *Updater) AppendHeaderAt(fh *FileHeader, offset int64) (io.Writer, error
 			}
 
 			// Rewind the ReadWriter offset to the one of the file to be deleted
-			_, err = u.rw.Seek(int64(u.dir[existingFileIndex].offset), io.SeekStart)
+			_, err = u.rw.Seek(int64(existingFileOffset), io.SeekStart)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
# Description

This PR modifies the `AppendHeaderAt()` method of the `Updater` struct to support overwriting files with the same name inside a zip archive.

# Proposed changes

The single commit in this PR changes the behavior of the `AppendHeaderAt()` method to check if a file with the same name as the one trying to be added already exists inside the zip archive.

If it exists its new data will be appended to the end of the file, making sure first that:
- the existing header is removed, 
- all the data in the archive is shifted to use the previous space it used, and
- the existing files header offsets are changed to reflect the data shift.